### PR TITLE
Builders: Use "posix" variant of the mingw64 cross compiler

### DIFF
--- a/builders/Dockerfile.mingw64
+++ b/builders/Dockerfile.mingw64
@@ -47,7 +47,13 @@ RUN set -ex && \
     # install NSIS and exiftool to inspect binary metadata
     nsis libimage-exiftool-perl osslsigncode \
     # Geany build dependencies \
-    python3-lxml python3-docutils
+    python3-lxml python3-docutils && \
+    # Use the "posix" variant of the mingw64 cross compiler to have support for recent C++ features
+    # like "std:future", see
+    # https://salsa.debian.org/mingw-w64-team/gcc-mingw-w64/-/blob/master/debian/gcc-mingw-w64-base.README.Debian
+    # and https://sourceforge.net/p/mingw-w64/bugs/959/ for details.
+    update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix && \
+    update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
 
 
 # copy scripts


### PR DESCRIPTION
The mingw64 cross compiler lacks support at least for "std:future" feature in C++ (https://sourceforge.net/p/mingw-w64/bugs/959/). Debian offers a "posix" variant which implements it.

https://sourceforge.net/p/mingw-w64/bugs/959/ describes the problem.

https://salsa.debian.org/mingw-w64-team/gcc-mingw-w64/-/blob/master/debian/gcc-mingw-w64-base.README.Debian explains that there is also a "-posix" variant of the cross compiler toolchain which *has* support for the relevant features.

It turned it we can use the "-posix" variant quite easily and so compilation of Scintilla works again.
We need to use the C++ runtime library from the compiler toolchain to be included in the installer which we need to change in the Geany CI build script. Everything else seems to work out of the box.

An alternative approach could be to use https://github.com/meganz/mingw-std-threads which, AFAIU, will implement the missing features for the "-win32" variant of the cross compiler toolchain. Though I couldn't get Scintilla compile against these headers. Either it doesn't work or I did it wrong.